### PR TITLE
Fix persistent array storage

### DIFF
--- a/Sources/EmojiKit/EmojiCategory+Persistency.swift
+++ b/Sources/EmojiKit/EmojiCategory+Persistency.swift
@@ -95,7 +95,8 @@ public extension EmojiCategory {
         let emojiChars = emojis.map { $0.char }
         let defaultMaxCount = getEmojisMaxCount(for: category)
         let value = emojiChars.prefix(maxCount ?? defaultMaxCount)
-        return storage.set(value, forKey: key)
+        let arrayValue = Array(value)
+        return storage.set(arrayValue, forKey: key)
     }
 
     /// Set the persisted emojis for a category.

--- a/Sources/EmojiKit/EmojiCategory+Persistency.swift
+++ b/Sources/EmojiKit/EmojiCategory+Persistency.swift
@@ -94,9 +94,8 @@ public extension EmojiCategory {
         let key = storageKey(for: category, value: .emojis)
         let emojiChars = emojis.map { $0.char }
         let defaultMaxCount = getEmojisMaxCount(for: category)
-        let value = emojiChars.prefix(maxCount ?? defaultMaxCount)
-        let arrayValue = Array(value)
-        return storage.set(arrayValue, forKey: key)
+        let value = Array(emojiChars.prefix(maxCount ?? defaultMaxCount))
+        return storage.set(value, forKey: key)
     }
 
     /// Set the persisted emojis for a category.


### PR DESCRIPTION
EmojiKit 1.5 introduced a crash when storing categories in User Defaults.
The array is shortened with prefix, which returns an ArraySlice, which cannot be stored in User Defaults.
This small change converts the ArraySlice to an Array before storing.
<img width="456" alt="Screenshot 2025-03-30 at 2 24 45 PM" src="https://github.com/user-attachments/assets/2315a465-0f66-4d8b-a96d-15356cdcc9bd" />
